### PR TITLE
is_valid_capture, capture, tests

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -17,4 +17,23 @@ class Pawn < Piece
 	  end
 	  false
 	end
+
+  def is_valid_capture?(dest_x, dest_y)
+	  # returns true if the destination contains an enemy
+	  # pawns have to check for diagonal
+	  return false if is_obstructed?(dest_x, dest_y)
+	  # white pawn
+		if self.player_id == self.game.white_player_id 
+			if (position_x - dest_x).abs == 1 && (dest_y - position_y) == 1
+				target_piece = self.game.pieces.where(position_x: dest_x, position_y: dest_y).first
+	  		return true if (target_piece && target_piece.player != self.player) 
+			end
+		else
+			if (position_x - dest_x).abs == 1 && (position_y - dest_y) == 1
+				target_piece = self.game.pieces.where(position_x: dest_x, position_y: dest_y).first
+	  		return true if (target_piece && target_piece.player != self.player) 
+	  	end
+		end
+		return false
+	end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -97,6 +97,26 @@ class Piece < ActiveRecord::Base
 		false		
 	end
 
+  def is_valid_capture?(dest_x, dest_y)
+    # returns true if the destination contains an enemy
+    # move is validated elsewhere (is_valid_move)
+    # pawn overrides this since it moves differently when capturing
+    target_piece = self.game.pieces.where(position_x: dest_x, position_y: dest_y).first
+    (!target_piece || target_piece.player == self.player) ? false : true
+  end
+
+  def capture(dest_x, dest_y)
+    # check if valid
+    # set the enemy piece to nil and off the board
+    # moving to the now empty spot, incrementing move_count, updating game.active_player is left to the move method
+    # return true on success, false on fail 
+    if self.is_valid_capture?(dest_x,dest_y)
+      target_piece = self.game.pieces.where(position_x: dest_x, position_y: dest_y).first
+      target_piece.update_attributes(position_x: nil, position_y: nil, is_active: false)
+      return true
+    end
+    return false
+  end
 
 end
 

--- a/spec/helpers/pieces_helper_spec.rb
+++ b/spec/helpers/pieces_helper_spec.rb
@@ -11,5 +11,5 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe PiecesHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  #pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -1,6 +1,94 @@
 require 'rails_helper'
 
 RSpec.describe Piece, type: :model do
+  describe "is_valid_capture? returns true if enemy is on destination" do
+    before :each do
+      @g = FactoryGirl.create(:joined_game)
+      @q = Queen.create(position_x:4, position_y: 4, game: @g, player: @g.white_player)
+    end      
+    it "returns true if enemy on destination" do
+      enemy = Pawn.create(position_x:4,position_y:7,game: @g, player: @g.black_player)
+      expect(@q.is_valid_capture?(4,7)).to eq true
+    end
+
+    it "returns false if no piece is on destination" do
+      expect(@q.is_valid_capture?(4,6)).to eq false
+    end
+
+    it "returns false if player's own piece is on destination" do
+      friend = Pawn.create(position_x: 4, position_y: 2, game: @g, player: @g.white_player)
+      expect(@q.is_valid_capture?(4,2)).to eq false
+    end
+  end
+
+  it "returns true when a non-pawn captures an enemy" do
+    g = FactoryGirl.create(:joined_game)
+    q = Queen.create(position_x: 4, position_y: 4, game: g, player: g.white_player)
+    enemy = Pawn.create(position_x: 4, position_y: 7, game: g, player: g.black_player)
+    expect(q.capture(4,7)).to eq true
+    enemy.reload
+    expect(enemy.is_active).to eq false
+    expect(enemy.position_x).to eq nil
+  end
+
+  it "returns false if non-pawn capture fails" do
+    g = FactoryGirl.create(:joined_game)
+    q = Queen.create(position_x: 4, position_y: 4, game: g, player: g.white_player)
+    friend = Pawn.create(position_x: 4, position_y: 3, game: g, player: g.white_player)
+    expect(q.capture(4,3)).to eq false
+    q.reload
+    expect(q.position_y).to eq 4
+  end
+
+  describe "is_valid_capture returns true when a pawn captures an enemy" do
+    it "returns true for a white pawn capturing" do
+      g = FactoryGirl.create(:joined_game)
+      p = Pawn.create(position_x: 4, position_y: 4, game: g, player: g.white_player)
+      enemy = Queen.create(position_x: 3, position_y: 5, game: g, player: g.black_player)
+      expect(p.capture(3,5)).to eq true
+      enemy.reload
+      expect(enemy.is_active).to eq false
+    end
+
+    it "returns true for a black pawn capturing" do
+      g = FactoryGirl.create(:joined_game)
+      p = Pawn.create(position_x: 4, position_y: 4, game: g, player: g.black_player)
+      enemy = Queen.create(position_x: 3, position_y: 3, game: g, player: g.white_player)
+      expect(p.capture(3,3)).to eq true
+      enemy.reload
+      expect(enemy.is_active).to eq false
+    end
+  end
+
+  describe "is_valid_capture returns false if pawn capture fails" do
+    it "returns false if move is not diagonal and one space" do
+      g = FactoryGirl.create(:joined_game)
+      p = Pawn.create(position_x: 4, position_y: 4, game: g, player: g.black_player)
+      enemy = Queen.create(position_x: 3, position_y: 2, game: g, player: g.white_player)
+      expect(p.capture(3,2)).to eq false
+    end
+
+    it "returns false if there is no enemy present" do
+      g = FactoryGirl.create(:joined_game)
+      p = Pawn.create(position_x: 4, position_y: 4, game: g, player: g.black_player)
+      expect(p.capture(3,3)).to eq false      
+    end
+
+    it "returns false if white pawn tries to capture southwards" do
+      g = FactoryGirl.create(:joined_game)
+      p = Pawn.create(position_x: 4, position_y: 4, game: g, player: g.white_player)
+      enemy = Queen.create(position_x: 3, position_y: 3, game: g, player: g.black_player)
+      expect(p.capture(3,3)).to eq false
+    end
+
+    it "returns false if black pawn tries to capture southwards" do
+      g = FactoryGirl.create(:joined_game)
+      p = Pawn.create(position_x: 4, position_y: 4, game: g, player: g.black_player)
+      enemy = Queen.create(position_x: 5, position_y: 5, game: g, player: g.white_player)
+      expect(p.capture(5,5)).to eq false
+    end
+  end
+
   describe "is_obstructed? returns false if path is not blocked" do
     before :each do
       @g = FactoryGirl.create(:joined_game)


### PR DESCRIPTION
This has 3 things:
is_valid_capture? (x,y) for a non-pawn object, just checks if destination has an enemy 
is_valid_capture? (x,y) for a pawn, checks destination but also checks black/white pawns are moving correctly on the diagonal. I didn't incorporate into is_valid_move? but it could go there, or an over-arching move method could call both in turn.
capture(x,y) is a piece method that updates the enemy piece, returns true for success. it does not update the capturing piece (position, move_count) or the game.active_player, again I was thinking there would be an over-arching move method that might want control of that.
