### PR TITLE
Enable Moving Pieces in DB

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -18,4 +18,17 @@ class PiecesController < ApplicationController
 
   end
 
+  def move
+    @piece = Piece.find(params[:id])
+    @game = Game.find(params[:game_id])
+    if @piece.is_valid_move?(params[:position_x], params[:position_y])
+      @piece.capture(params[:position_x], params[:position_y])
+      @move_count = @piece.move_count + 1
+      @piece.update_attributes(position_x: params[:position_x], position_y: params[:position_y], move_count: @move_count, is_selected: false)
+    else
+      flash[:alert] = "Invalid Move"
+    end
+    redirect_to game_path(@game)
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     resources :pieces, only: [:update] do
       member do
         patch :select
+        patch :move
       end
     end
   end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -2,4 +2,31 @@ require 'rails_helper'
 
 RSpec.describe PiecesController, type: :controller do
 
+  describe "pieces#move action" do
+    before :each do
+      @g = FactoryGirl.create(:joined_game)
+      @q = Queen.create(position_x: 4, position_y: 4, game: @g, player: @g.white_player)
+    end
+
+    it "should successfully change a piece's location if the destination is valid" do
+      patch :move, { id: @q.id, game_id: @g.id, position_x: 6, position_y: 6, format: :json}
+      expect(response).to redirect_to game_path(@g)
+      @q.reload
+      expect(@q.move_count).to eq 1
+      expect(@q.is_selected).to eq false
+      expect(@q.position_x).to eq 6
+      expect(@q.position_y).to eq 6 
+    end
+
+    it "should not change a piece's location if the destination is invalid" do
+      patch :move, { id: @q.id, game_id: @g.id, position_x: 5, position_y: 6, format: :json}
+      expect(flash[:alert]).to eq "Invalid Move"
+      expect(response).to redirect_to game_path(@g)
+      @q.reload
+      expect(@q.move_count).to eq 0
+      expect(@q.position_x).to eq 4
+      expect(@q.position_y).to eq 4 
+    end
+  end
+
 end


### PR DESCRIPTION
Backend for moving pieces in the db. Uses is_valid_move? -- it if evaluates to true the piece is captured, the move count is incremented, and the positions are updated. Left turn handling for later since it is a separate task in Trello, but I assume it will be handled in this move method. 

Note that this assumes an AJAX patch request will be integrated later and call the method when we build drag & drop support. Right now the only way I made sure it works was to write some tests in pieces_controller_spec.rb. 
