### PR TITLE
Turn handling

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -34,6 +34,7 @@ class GamesController < ApplicationController
     @game = Game.find(params[:id])
     @game.update_attributes(black_player: current_user)
     @game.setup
+    @game.update_attributes(active_player: @game.white_player)
     redirect_to game_path(@game)
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -25,6 +25,11 @@ class PiecesController < ApplicationController
       @piece.capture(params[:position_x], params[:position_y])
       @move_count = @piece.move_count + 1
       @piece.update_attributes(position_x: params[:position_x], position_y: params[:position_y], move_count: @move_count, is_selected: false)
+      if @piece.player == @game.white_player
+        @game.update_attributes(active_player: @game.black_player)
+      else
+        @game.update_attributes(active_player: @game.white_player)
+      end
     else
       flash[:alert] = "Invalid Move"
     end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -4,6 +4,16 @@ class Game < ActiveRecord::Base
   belongs_to :active_player, class_name: "User"
   has_many :pieces
 
+  validate :valid_active_player?
+
+  def valid_active_player?
+    if active_player
+      if (active_player != white_player) && (active_player != black_player)
+        errors.add(:active_player,'Invalid active player!')
+      end
+    end
+  end
+
 def setup
   (1..8).each do |num|
     Pawn.create(game: self, player: self.white_player, position_x: num, position_y: 2)

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,5 +1,14 @@
 <h1><%= @game.name %></h1>
 
+<% if @game.active_player %>
+	<% if @game.active_player == @game.white_player %>
+		<h3>White (<%= @game.active_player.email %>) to move</h3>
+	<% elsif @game.active_player == @game.black_player %>
+		<h3>Black (<%= @game.active_player.email %>) to move</h3>
+	<% end %>
+<% end %>	
+
+<br>
 <div class="chess_board_container">
 	<table class="chess_board_table">
 		
@@ -134,7 +143,7 @@
 		drawPieces();
 	});
 
-//mine
+
 	$(".piece").click(toggleSelect);
 
 	function toggleSelect(e){
@@ -148,6 +157,6 @@
 		});
 	} 
 
-//end
+
 
 </script>

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe GamesController, type: :controller do
       expect(game.white_player).to eq(user)
     end
 
+
   end
 
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe PiecesController, type: :controller do
       expect(@q.position_x).to eq 4
       expect(@q.position_y).to eq 4 
     end
+
+    it "should change the active player to black if white moves" do
+      patch :move, { id: @q.id, game_id: @g.id, position_x: 6, position_y: 6, format: :json}
+      @g.reload
+      expect(@g.active_player).to eq @g.black_player
+    end
+
   end
 
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Game, type: :model do
 
   context "active_player validation" do
     it "allows active_player to be white player" do
-      g=FactoryGirl.create(:game)
+      g=FactoryGirl.create(:joined_game)
       g.active_player_id = g.white_player_id
       expect(g).to be_valid
       expect(g.active_player_id).to eq g.white_player_id

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -15,4 +15,27 @@ RSpec.describe Game, type: :model do
     expect(g.black_player).to_not be nil
   end
 
+  context "active_player validation" do
+    it "allows active_player to be white player" do
+      g=FactoryGirl.create(:game)
+      g.active_player_id = g.white_player_id
+      expect(g).to be_valid
+      expect(g.active_player_id).to eq g.white_player_id
+    end
+
+    it "allows active_player to be black player" do
+      g=FactoryGirl.create(:joined_game)
+      g.active_player_id = g.black_player_id
+      expect(g).to be_valid
+      expect(g.active_player_id).to eq g.black_player_id
+    end
+
+    it "does not allow active_player to be some third player" do
+      g=FactoryGirl.create(:joined_game)
+      u= FactoryGirl.create(:user)
+      g.active_player_id = u.id
+      expect(g).to_not be_valid
+    end
+  end
+
 end


### PR DESCRIPTION
Add validation for active_player field. 
Set active_player to white when game is joined (after pieces are set up).
Change active_player if piece move is successful.
Show who the active player is on game show.
