### PR TITLE
Add focus to new game name on game creation page.

### DIFF
--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -3,3 +3,7 @@
   <%= f.text_field :name %>
   <%= f.submit "Create Game!" %>
 <% end %>
+
+<script>
+	$('#game_name').focus();
+</script>


### PR DESCRIPTION
Used jquery to add focus to game name input field on game creation page.  This can also be done with html autofocus attribute, but it may not be supported in some older versions of IE.
