### PR TITLE
Bug fix

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -425,6 +425,7 @@
 		var choosePiece = $('.choosepiece');
 		choosePiece.click(function(event){
 		var pieceType = $(event.target).data('piece-type');
+    var pieceColor = $(event.target).data('piece-color');
 			var data = {type:pieceType, _method: 'PATCH'};
 			var pieceUrl = "/games/" + <%=@game.id%> + "/pieces/" + pieceId + "/promote"; 
 			$.post(pieceUrl, data
@@ -432,6 +433,18 @@
 					$('.whitepromotion').css("display", "none");
 					$('.blackpromotion').css("display", "none");
 					drawPieces();
+//
+          if (pieceColor === 'black'){
+            gameRef.update({
+              active_player_id: "<%=@game.white_player_id %>"
+            });
+          }
+          else {
+            gameRef.update({
+              active_player_id: "<%=@game.black_player_id %>"
+            });
+          }
+//
 				});
 		});		
 	}
@@ -509,17 +522,21 @@
 					
 	        console.log('We have movement!');
 
-         if (selectedPiece.attr('data-piece-color') === 'black') {
-              console.log('updating active player to white');
-              gameRef.update({
-              	active_player_id: "<%=@game.white_player_id %>"
-              });
+          if (!promotion) {
+            // only update active turn if it's not a promotion
+           if (selectedPiece.attr('data-piece-color') === 'black') {
+                console.log('updating active player to white');
+                gameRef.update({
+                	active_player_id: "<%=@game.white_player_id %>"
+                });
+            }
+            else {
+                gameRef.update({
+                  active_player_id: "<%=@game.black_player_id %>"
+                });
+            }
           }
-          else {
-              gameRef.update({
-                active_player_id: "<%=@game.black_player_id %>"
-              });
-          }
+
           console.log('calling updateActivePlayer from within moveSelectedPiece');
           updateActivePlayer();           
         }

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -189,8 +189,8 @@
 						$('.board_square[data-position-x='+ piece.position_x + '][data-position-y=' + piece.position_y + ']').html(clonedPiece);
 						//updateActivePlayer();
         	}
-				  updateActivePlayer();
 				});
+        updateActivePlayer();
       }, error: function (data) {
         console.log('Chess pieces failed to load!');
       }

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -433,7 +433,6 @@
 					$('.whitepromotion').css("display", "none");
 					$('.blackpromotion').css("display", "none");
 					drawPieces();
-//
           if (pieceColor === 'black'){
             gameRef.update({
               active_player_id: "<%=@game.white_player_id %>"
@@ -444,7 +443,6 @@
               active_player_id: "<%=@game.black_player_id %>"
             });
           }
-//
 				});
 		});		
 	}


### PR DESCRIPTION
-- stop redundant calls to updateActivePlayer from within drawPieces
-- don't update the firebase active player until a pawn promotion is completed (now redraws successfully after player does promotion)
